### PR TITLE
Add recognition of steam 'specials' scam/advertisement

### DIFF
--- a/NoAdsHere/Common/BlockType.cs
+++ b/NoAdsHere/Common/BlockType.cs
@@ -4,6 +4,7 @@ namespace NoAdsHere.Common
     {
         InstantInvite,
         YoutubeLink,
+        SteamScam,
         TwitchStream,
         TwitchVideo,
         TwitchClip,

--- a/NoAdsHere/Services/AntiAds/AntiAds.cs
+++ b/NoAdsHere/Services/AntiAds/AntiAds.cs
@@ -34,6 +34,8 @@ namespace NoAdsHere.Services.AntiAds
 
         private static readonly Regex YoutubeLink = new Regex(@"youtu(?:\.be|be\.com)\/(?:.*v(?:\/|=)|(?:.*\/)?)([a-zA-Z0-9-_]+)", RegexOptions.Compiled & RegexOptions.IgnoreCase);
 
+        private static readonly Regex SteamScam = new Regex(@"steam(?:reward|special|summer)\.com/?\?id=\w+", RegexOptions.Compiled & RegexOptions.IgnoreCase);
+
         public static Task Install(IServiceProvider provider)
         {
             _database = provider.GetRequiredService<DatabaseService>();
@@ -148,6 +150,17 @@ namespace NoAdsHere.Services.AntiAds
                             await TryDelete(context, BlockType.YoutubeLink).ConfigureAwait(false);
                             await Violations.Violations.Add(context, BlockType.YoutubeLink);
                         }
+                }
+                if (ActiveGuilds[BlockType.SteamScam].Contains(context.Guild.Id))
+                {
+                    if (SteamScam.IsMatch(rawmsg))
+                    {
+                        if (await IsToDelete(context, BlockType.SteamScam).ConfigureAwait(false))
+                        {
+                            await TryDelete(context, BlockType.SteamScam).ConfigureAwait(false);
+                            await Violations.Violations.Add(context, BlockType.SteamScam);
+                        }
+                    }
                 }
             });
             await Task.CompletedTask.ConfigureAwait(false);

--- a/NoAdsHere/Services/Violations/Violations.cs
+++ b/NoAdsHere/Services/Violations/Violations.cs
@@ -162,8 +162,8 @@ namespace NoAdsHere.Services.Violations
                 case BlockType.YoutubeLink:
                     return "Message contained a YouTube Link.";
 
-                case BlockType.All:
-                    return "[Error] This Message should never appear!";
+                case BlockType.SteamScam:
+                    return "Message contained a Steam Advertisement Link!";
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(blockType), blockType, null);


### PR DESCRIPTION
Don't know the ordering in `BlockType`, so yell at me if it's not to your liking.

So recently we've had to delete a lot of these, manually, and figured it would be a good addition.
What do you think?