### PR TITLE
Using a memory cache can speed up database access and reduce the load on disk.

### DIFF
--- a/NoAdsHere/Database/NoAdsHereContext.cs
+++ b/NoAdsHere/Database/NoAdsHereContext.cs
@@ -16,7 +16,7 @@ namespace NoAdsHere.Database
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            optionsBuilder.UseSqlite(@"Data Source=NoAdsHere.db");
+            optionsBuilder.UseSqlite(@"Data Source=NoAdsHere.db").UseMemoryCache(null);
         }
     }
 }


### PR DESCRIPTION
Using `null` means that EF will automatically create and manage the memory cache.

I used this method on my Discord bot that had customizable prefixes - there is a huge, noticeable difference.